### PR TITLE
Add experiment framework and shared data loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-sublinear regret experiment
+# Sub-linear Regret Experiment
+
+This experiment evaluates whether the Memory-Pair learner achieves sub-linear cumulative regret on drifting and adversarial streams. It depends on the shared `data_loader` module and the `code.memory_pair` implementation.
+
+## Quick Start
+
+```bash
+git clone https://github.com/<USER>/memory-pair-exp.git
+cd memory-pair-exp
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python run.py --dataset rotmnist --stream drift --algo memorypair --T 100000
+```
+
+Results (CSV and PNG) are written to the `results/` directory and committed automatically.

--- a/baselines.py
+++ b/baselines.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+class OnlineSGD:
+    def __init__(self, dim, lr=0.1):
+        self.theta = np.zeros(dim)
+        self.lr = lr
+
+    def step(self, x, y):
+        pred = self.theta @ x
+        grad = (pred - y) * x
+        self.theta -= self.lr * grad
+        return 0.5 * (pred - y) ** 2
+
+class AdaGrad:
+    def __init__(self, dim, lr=1.0, eps=1e-8):
+        self.theta = np.zeros(dim)
+        self.lr = lr
+        self.eps = eps
+        self.G = np.zeros(dim)
+
+    def step(self, x, y):
+        pred = self.theta @ x
+        grad = (pred - y) * x
+        self.G += grad ** 2
+        adjusted_lr = self.lr / (np.sqrt(self.G) + self.eps)
+        self.theta -= adjusted_lr * grad
+        return 0.5 * (pred - y) ** 2
+
+class OnlineNewtonStep:
+    def __init__(self, dim, lam=1.0):
+        self.theta = np.zeros(dim)
+        self.H = lam * np.eye(dim)
+
+    def step(self, x, y):
+        pred = self.theta @ x
+        grad = (pred - y) * x
+        self.H += np.outer(x, x)
+        self.theta -= np.linalg.inv(self.H) @ grad
+        return 0.5 * (pred - y) ** 2

--- a/data_loader/README.md
+++ b/data_loader/README.md
@@ -1,0 +1,11 @@
+# Data Loader
+
+Shared dataset loaders with deterministic fallbacks. Available loaders:
+
+| key      | function                      |
+|----------|-------------------------------|
+| rotmnist | `get_rotating_mnist_stream`   |
+| cifar10  | `get_cifar10_stream`          |
+| covtype  | `get_covtype_stream`          |
+
+Run `python sanity_check.py` to verify deterministic streams.

--- a/data_loader/__init__.py
+++ b/data_loader/__init__.py
@@ -1,0 +1,10 @@
+from .mnist import get_rotating_mnist_stream
+from .cifar10 import get_cifar10_stream
+from .covtype import get_covtype_stream
+from .streams import make_stream
+__all__ = [
+    'get_rotating_mnist_stream',
+    'get_cifar10_stream',
+    'get_covtype_stream',
+    'make_stream',
+]

--- a/data_loader/cifar10.py
+++ b/data_loader/cifar10.py
@@ -1,0 +1,44 @@
+import os
+import numpy as np
+from .utils import set_global_seed
+from .streams import make_stream
+
+try:
+    from torchvision.datasets import CIFAR10
+except Exception:
+    CIFAR10 = None
+
+DATA_DIR = os.path.expanduser("~/.cache/memory_pair_data/cifar10")
+
+
+def _simulate_cifar10(n=60000, seed=42):
+    set_global_seed(seed)
+    X = np.random.randint(0, 256, size=(n, 32, 32, 3), dtype=np.uint8)
+    y = np.random.randint(0, 10, size=(n,), dtype=np.uint8)
+    return X, y
+
+
+def download_cifar10(data_dir=DATA_DIR, split="train"):
+    if CIFAR10 is None:
+        return _simulate_cifar10(seed=42)
+    try:
+        dataset = CIFAR10(data_dir, train=(split == "train"), download=True)
+        X = dataset.data
+        y = np.array(dataset.targets)
+        return X, y
+    except Exception:
+        return _simulate_cifar10(seed=42)
+
+
+def get_cifar10_stream(mode="iid", batch_size=1, seed=42):
+    X, y = download_cifar10()
+
+    def drift_fn(imgs):
+        return np.roll(imgs, 1, axis=2)
+
+    def adv_fn(indices):
+        rng = np.random.default_rng(seed)
+        rng.shuffle(indices)
+        return indices
+
+    return make_stream(X, y, mode=mode, drift_fn=drift_fn, adv_fn=adv_fn, seed=seed)

--- a/data_loader/covtype.py
+++ b/data_loader/covtype.py
@@ -1,0 +1,44 @@
+import os
+import numpy as np
+from .utils import set_global_seed
+from .streams import make_stream
+
+try:
+    from sklearn.datasets import fetch_covtype
+except Exception:
+    fetch_covtype = None
+
+DATA_DIR = os.path.expanduser("~/.cache/memory_pair_data/covtype")
+
+
+def _simulate_covtype(n=581012, d=54, seed=42):
+    set_global_seed(seed)
+    X = np.random.randn(n, d).astype(np.float32)
+    y = np.random.randint(0, 7, size=(n,), dtype=np.int64)
+    return X, y
+
+
+def download_covtype(data_dir=DATA_DIR):
+    if fetch_covtype is None:
+        return _simulate_covtype(seed=42)
+    try:
+        data = fetch_covtype(data_home=data_dir)
+        X = data.data.astype(np.float32)
+        y = data.target.astype(np.int64)
+        return X, y
+    except Exception:
+        return _simulate_covtype(seed=42)
+
+
+def get_covtype_stream(mode="iid", batch_size=1, seed=42):
+    X, y = download_covtype()
+
+    def drift_fn(tab):
+        return tab + 0.1 * np.random.randn(*tab.shape)
+
+    def adv_fn(indices):
+        rng = np.random.default_rng(seed)
+        rng.shuffle(indices)
+        return indices
+
+    return make_stream(X, y, mode=mode, drift_fn=drift_fn, adv_fn=adv_fn, seed=seed)

--- a/data_loader/mnist.py
+++ b/data_loader/mnist.py
@@ -1,0 +1,44 @@
+import os
+import numpy as np
+from .utils import set_global_seed, download_with_progress
+from .streams import make_stream
+
+try:
+    from torchvision.datasets import MNIST
+except Exception:
+    MNIST = None
+
+DATA_DIR = os.path.expanduser("~/.cache/memory_pair_data/mnist")
+
+
+def _simulate_mnist(n=70000, seed=42):
+    set_global_seed(seed)
+    X = np.random.randint(0, 256, size=(n, 28, 28), dtype=np.uint8)
+    y = np.random.randint(0, 10, size=(n,), dtype=np.uint8)
+    return X, y
+
+
+def download_rotating_mnist(data_dir=DATA_DIR, split="train"):
+    if MNIST is None:
+        return _simulate_mnist(seed=42)
+    try:
+        dataset = MNIST(data_dir, train=(split == "train"), download=True)
+        X = dataset.data.numpy()
+        y = dataset.targets.numpy()
+        return X, y
+    except Exception:
+        return _simulate_mnist(seed=42)
+
+
+def get_rotating_mnist_stream(mode="iid", batch_size=1, seed=42):
+    X, y = download_rotating_mnist()
+
+    def drift_fn(imgs):
+        return np.rot90(imgs, k=1, axes=(1, 2))
+
+    def adv_fn(indices):
+        rng = np.random.default_rng(seed)
+        rng.shuffle(indices)
+        return indices
+
+    return make_stream(X, y, mode=mode, drift_fn=drift_fn, adv_fn=adv_fn, seed=seed)

--- a/data_loader/requirements.txt
+++ b/data_loader/requirements.txt
@@ -1,0 +1,2 @@
+torchvision
+scikit-learn

--- a/data_loader/sanity_check.py
+++ b/data_loader/sanity_check.py
@@ -1,0 +1,22 @@
+import click
+from . import get_rotating_mnist_stream, get_covtype_stream
+from .utils import sha256_of_stream
+
+DATASET_MAP = {
+    "rotmnist": get_rotating_mnist_stream,
+    "covtype": get_covtype_stream,
+}
+
+@click.command()
+@click.option("--dataset", type=click.Choice(list(DATASET_MAP.keys())), required=True)
+@click.option("--mode", type=click.Choice(["iid", "drift", "adv"]), default="iid")
+@click.option("--t", type=int, default=5000)
+def main(dataset, mode, t):
+    gen = DATASET_MAP[dataset](mode=mode, seed=42)
+    for i, sample in zip(range(5), gen):
+        print(sample)
+    sha = sha256_of_stream(gen, T=t)
+    print("SHA256", sha)
+
+if __name__ == "__main__":
+    main()

--- a/data_loader/streams.py
+++ b/data_loader/streams.py
@@ -1,0 +1,16 @@
+import numpy as np
+from .utils import set_global_seed
+
+def make_stream(X, y, mode="iid", drift_fn=None, adv_fn=None, seed=42):
+    set_global_seed(seed)
+    n = len(X)
+    indices = np.arange(n)
+    step = 0
+    while True:
+        i = indices[step % n]
+        yield X[i], y[i]
+        step += 1
+        if mode == "drift" and step % 1000 == 0 and drift_fn is not None:
+            X = drift_fn(X)
+        if mode == "adv" and step % 500 == 0 and adv_fn is not None:
+            indices = adv_fn(indices)

--- a/data_loader/utils.py
+++ b/data_loader/utils.py
@@ -1,0 +1,36 @@
+import os
+import random
+import hashlib
+import urllib.request
+
+import numpy as np
+
+
+def set_global_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    try:
+        import torch
+        torch.manual_seed(seed)
+    except Exception:
+        pass
+
+
+def download_with_progress(url: str, target_path: str):
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+    if os.path.exists(target_path):
+        return target_path
+    with urllib.request.urlopen(url) as response, open(target_path, 'wb') as out:
+        data = response.read()
+        out.write(data)
+    return target_path
+
+
+def sha256_of_stream(generator, T=1000):
+    h = hashlib.sha256()
+    for i, (x, y) in enumerate(generator):
+        h.update(x.tobytes())
+        h.update(bytes([int(y)]))
+        if i + 1 >= T:
+            break
+    return h.hexdigest()

--- a/plotting.py
+++ b/plotting.py
@@ -1,0 +1,15 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+def plot_regret(csv_path, png_path):
+    data = np.loadtxt(csv_path, delimiter=",", skiprows=1)
+    steps, regret = data[:,0], data[:,1]
+    plt.figure()
+    plt.loglog(steps, regret, label="regret")
+    plt.loglog(steps, np.sqrt(steps), linestyle="--", label="sqrt(T)")
+    plt.xlabel("step")
+    plt.ylabel("cumulative regret")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(png_path)
+    plt.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.2
+numpy
+pandas
+matplotlib
+click
+tqdm

--- a/run.py
+++ b/run.py
@@ -1,0 +1,63 @@
+import csv
+import os
+import click
+import numpy as np
+from tqdm import tqdm
+
+from baselines import OnlineSGD, AdaGrad, OnlineNewtonStep
+from plotting import plot_regret
+
+from data_loader import get_rotating_mnist_stream, get_covtype_stream
+from code.memory_pair.src.memory_pair import MemoryPair
+
+ALGO_MAP = {
+    "memorypair": MemoryPair,
+    "sgd": OnlineSGD,
+    "adagrad": AdaGrad,
+    "ons": OnlineNewtonStep,
+}
+
+DATASET_MAP = {
+    "rotmnist": get_rotating_mnist_stream,
+    "covtype": get_covtype_stream,
+}
+
+@click.command()
+@click.option("--dataset", type=click.Choice(["rotmnist", "covtype"]), required=True)
+@click.option("--stream", type=click.Choice(["iid", "drift", "adv"]), default="iid")
+@click.option("--algo", type=click.Choice(list(ALGO_MAP.keys())), default="memorypair")
+@click.option("--t", "--T", type=int, default=100000)
+@click.option("--seed", type=int, default=42)
+def main(dataset, stream, algo, t, seed):
+    gen_fn = DATASET_MAP[dataset]
+    stream_gen = gen_fn(mode=stream, batch_size=1, seed=seed)
+    first_x, _ = next(stream_gen)
+    dim = first_x.size
+    algo_cls = ALGO_MAP[algo]
+    model = algo_cls(dim)
+
+    csv_path = os.path.join("results", f"{dataset}_{stream}_{algo}.csv")
+    png_path = csv_path.replace(".csv", ".png")
+    cum_regret = 0.0
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["step", "regret"])
+        x, y = first_x, _
+        loss = model.step(x, y)
+        cum_regret += loss
+        writer.writerow([1, cum_regret])
+        for step, (x, y) in enumerate(stream_gen, start=2):
+            loss = model.step(x, y)
+            cum_regret += loss
+            if step % 100 == 0:
+                writer.writerow([step, cum_regret])
+            if step >= t:
+                break
+
+    plot_regret(csv_path, png_path)
+    os.system("git add results/*")
+    hash_short = os.popen("git rev-parse --short HEAD").read().strip()
+    os.system(f"git commit -m 'EXP:sublinear_regret {dataset}-{stream}-{algo} {hash_short}'")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement the experiment driver, plotting helper, and baseline algorithms
- add README with reproducibility instructions and requirements
- create `data_loader` module providing MNIST/CIFAR10/COVTYPE streams with fallback simulation
- include `sanity_check.py` for deterministic loader verification
- keep `results` directory tracked with `.gitkeep`

## Testing
- `python -m py_compile baselines.py plotting.py run.py data_loader/*.py`
- `python3 -m data_loader.sanity_check --dataset rotmnist --mode drift --t 5`
- `python3 -m data_loader.sanity_check --dataset covtype --mode adv --t 10`


------
https://chatgpt.com/codex/tasks/task_e_68791e94797c833192440cb6335ce35d